### PR TITLE
Added new 'hasAirQualityObserved' relationship to the AgriParcel data model

### DIFF
--- a/AgriParcel/ADOPTERS.yaml
+++ b/AgriParcel/ADOPTERS.yaml
@@ -1,10 +1,9 @@
 description: This is a compilation list of the current adopters of the data model AgriParcel of the Subject dataModel.Agrifood.  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
 currentAdopters:
--
- adopter: 
- description: 
- mail: 
- organization: 
- project: 
- comments: 
- startDate: 
+- adopter: SALTED project
+  description: Characterization of SIGPAC parcels for a Smart Agriculture use case.
+  mail: 
+  organization: 
+  project: https://salted-project.eu/
+  comments: 
+  startDate: 

--- a/AgriParcel/examples/example-geojsonfeature.json
+++ b/AgriParcel/examples/example-geojsonfeature.json
@@ -116,6 +116,10 @@
       "type": "Relationship",
       "object": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8"
     },
+    "hasAirQualityObserved": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+    },
     "cropStatus": {
       "type": "Property",
       "value": "seeded"

--- a/AgriParcel/examples/example-normalized.json
+++ b/AgriParcel/examples/example-normalized.json
@@ -64,7 +64,7 @@
   },
   "hasAirQualityObserved": {
     "type": "Relationship",
-    "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+    "value": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
   },
   "cropStatus": {
     "value": "seeded"

--- a/AgriParcel/examples/example-normalized.json
+++ b/AgriParcel/examples/example-normalized.json
@@ -62,6 +62,10 @@
     "type": "Relationship",
     "value": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8"
   },
+  "hasAirQualityObserved": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+  },
   "cropStatus": {
     "value": "seeded"
   },

--- a/AgriParcel/examples/example-normalized.jsonld
+++ b/AgriParcel/examples/example-normalized.jsonld
@@ -41,6 +41,10 @@
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df"
     },
+    "hasAirQualityObserved": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+    },
     "hasDevice": {
         "type": "Relationship",
         "object": [

--- a/AgriParcel/examples/example.json
+++ b/AgriParcel/examples/example.json
@@ -28,6 +28,7 @@
     "urn:ngsi-ld:AgriParcel:2d5b8874-4474-11e8-8d6b-dbe14425b5e4"
   ],
   "hasAgriCrop": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8",
+  "hasAirQualityObserved": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B",
   "cropStatus": "seeded",
   "lastPlantedAt": "2016-08-23T10:18:16Z",
   "hasAgriSoil": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df",

--- a/AgriParcel/examples/example.jsonld
+++ b/AgriParcel/examples/example.jsonld
@@ -14,6 +14,7 @@
     ],
     "hasAgriParcelParent": "urn:ngsi-ld:AgriParcel:1ea0f120-4474-11e8-9919-672036642081",
     "hasAgriSoil": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df",
+    "hasAirQualityObserved": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B",
     "hasDevice": [
         "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",
         "urn:ngsi-ld:Device:63217d24-4474-11e8-9da2-c3dd3c36891b",

--- a/AgriParcel/schema.json
+++ b/AgriParcel/schema.json
@@ -115,6 +115,23 @@
                 ],
                 "description": "Relationship. Reference to the soil associated with this parcel of land"
             },
+            "hasAirQualityObserved": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                        "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                        "description": "Property. Identifier format of any NGSI entity"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Property. Identifier format of any NGSI entity"
+                    }
+                ],
+                "description": "Relationship. Reference to the air quality observed in this parcel of land"
+            },
             "cropStatus": {
                 "type": "string",
                 "description": "Property. Enum:'seeded, justBorn, growing, maturing, readyForHarvesting'. A choice from an enumerated list describing the crop planting status",

--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -56,3 +56,25 @@ contributors:
   project: 
   comments: 
   year: 2022
+- name: Laura
+  surname: Martín
+  mail: lmartin@tlmat.unican.es
+  organization: Universidad de Cantabria (UC)
+  project: SALTED. https://salted-project.eu/
+  comments:
+  year: 2023
+- name: Víctor
+  surname: González
+  mail: vgonzalez@tlmat.unican.es
+  organization: Universidad de Cantabria (UC)
+  project: SALTED. https://salted-project.eu/
+  comments:
+  year: 2023
+- name: José Ricardo
+  surname: Rodríguez
+  mail: jricardo.rodriguez@grupoamper.com
+  organization: Grupo AMPER
+  project: SALTED. https://salted-project.eu/
+  comments:
+  year: 2023
+  


### PR DESCRIPTION
Addition of a new relationship, 'hasAirQualityObserved', to the AgriParcel data model. This allows for AirQualityObserved entities to be correlated with the AgriParcel where they were generated. To be used in a Smart Agriculture use case.