### PR TITLE
Redefinition of the hasAirQualityObserved relationship within AgriParcel

### DIFF
--- a/AgriParcel/examples/example-geojsonfeature.json
+++ b/AgriParcel/examples/example-geojsonfeature.json
@@ -118,7 +118,7 @@
     },
     "hasAirQualityObserved": {
       "type": "Relationship",
-      "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+      "object": [ "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B" ]
     },
     "cropStatus": {
       "type": "Property",

--- a/AgriParcel/examples/example-normalized.json
+++ b/AgriParcel/examples/example-normalized.json
@@ -64,7 +64,7 @@
   },
   "hasAirQualityObserved": {
     "type": "Relationship",
-    "value": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+    "value": [ "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B" ]
   },
   "cropStatus": {
     "value": "seeded"

--- a/AgriParcel/examples/example-normalized.jsonld
+++ b/AgriParcel/examples/example-normalized.jsonld
@@ -43,7 +43,7 @@
     },
     "hasAirQualityObserved": {
         "type": "Relationship",
-        "object": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B"
+        "object": [ "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B" ]
     },
     "hasDevice": {
         "type": "Relationship",

--- a/AgriParcel/examples/example.json
+++ b/AgriParcel/examples/example.json
@@ -28,7 +28,7 @@
     "urn:ngsi-ld:AgriParcel:2d5b8874-4474-11e8-8d6b-dbe14425b5e4"
   ],
   "hasAgriCrop": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8",
-  "hasAirQualityObserved": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B",
+  "hasAirQualityObserved": [ "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B" ],
   "cropStatus": "seeded",
   "lastPlantedAt": "2016-08-23T10:18:16Z",
   "hasAgriSoil": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df",

--- a/AgriParcel/examples/example.jsonld
+++ b/AgriParcel/examples/example.jsonld
@@ -14,7 +14,7 @@
     ],
     "hasAgriParcelParent": "urn:ngsi-ld:AgriParcel:1ea0f120-4474-11e8-9919-672036642081",
     "hasAgriSoil": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df",
-    "hasAirQualityObserved": "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B",
+    "hasAirQualityObserved": [ "urn:ngsi-ld:AirQualityObserved:B3F76EA170D030BCD9E036DCC9BEA22B" ],
     "hasDevice": [
         "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",
         "urn:ngsi-ld:Device:63217d24-4474-11e8-9da2-c3dd3c36891b",

--- a/AgriParcel/schema.json
+++ b/AgriParcel/schema.json
@@ -127,21 +127,24 @@
           "description": "Relationship. Reference to the soil associated with this parcel of land"
         },
         "hasAirQualityObserved": {
-          "anyOf": [
-            {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256,
-              "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
-              "description": "Property. Identifier format of any NGSI entity"
-            },
-            {
-              "type": "string",
-              "format": "uri",
-              "description": "Property. Identifier format of any NGSI entity"
-            }
-          ],
-          "description": "Relationship. Reference to the air quality observed in this parcel of land"
+          "type": "array",
+          "description": "Relationship. Reference to the air quality observed in this parcel of land",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                "description": "Property. Identifier format of any NGSI entity"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "description": "Property. Identifier format of any NGSI entity"
+              }
+            ]
+          }
         },
         "cropStatus": {
           "type": "string",


### PR DESCRIPTION
Redefined it as an array of strings in order to enable the possibility of having several AirQualityObserved entities measured within an AgriParcel entity.